### PR TITLE
Update to use official saucy

### DIFF
--- a/dockenstack/Dockerfile
+++ b/dockenstack/Dockerfile
@@ -1,7 +1,7 @@
 # Eric Windisch '2014
 # Forked from code by original author: Paul Czarkowski
 
-FROM ubuntu:raring
+FROM ubuntu:saucy
 MAINTAINER Eric Windisch "ewindisch@docker.com"
 
 EXPOSE 80 5000 8773 8774 8776 9292


### PR DESCRIPTION
As there is no trusty LTS image in the docker registry yet, use saucy to build devstack.
