### PR TITLE
apt remove python-six also removed python-pip

### DIFF
--- a/dockenstack/Dockerfile
+++ b/dockenstack/Dockerfile
@@ -67,6 +67,9 @@ RUN apt-get install -q -y dbus; \
 # Mask python-six because the apt package can conflict with the pypi version.
 RUN apt-get remove -q -y python-six
 
+# python-pip just became collatoral damage.  reinstall it.
+RUN apt-get install -q -y python-pip
+
 # Install six from pip before getting from global-requirements (due to bugs...)
 RUN pip install six
 


### PR DESCRIPTION
![kanyestack](https://cloud.githubusercontent.com/assets/2488346/3416734/e45cf98e-fe2f-11e3-9e70-8d283498c854.jpg)
