### PR TITLE
Install https method of apt and set TERM env.

### DIFF
--- a/dockenstack/Dockerfile
+++ b/dockenstack/Dockerfile
@@ -5,7 +5,11 @@ FROM ubuntu:trusty
 MAINTAINER Eric Windisch "ewindisch@docker.com"
 
 EXPOSE 80 5000 8773 8774 8776 9292
-
+# Set TERM env variable to avoid warning like "debconf: (TERM is not set, so the dialog frontend is not usable.)"
+ENV TERM=xterm
+# Install https methods of apt ; needed to install lxc-docker package
+# Without this, it gives error 'The method driver /usr/lib/apt/methods/https could not be found.'
+RUN apt-get install -qqy apt-transport-https
 # Install Docker
 RUN apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9; \
     echo 'deb http://get.docker.io/ubuntu docker main' > /etc/apt/sources.list.d/docker.list; \

--- a/dockenstack/Dockerfile
+++ b/dockenstack/Dockerfile
@@ -17,13 +17,15 @@ RUN apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys 36A1D786
     apt-get install -qqy lxc-docker
 
 # Install utilities
-RUN apt-get -qqy install git socat curl sudo apt-transport-https vim wget net-tools
+RUN apt-get -qqy install git socat curl sudo vim wget net-tools
 
 # Install apparmor
 RUN apt-get -qqy install apparmor
 
 # Extra requirements for pip-requirements
-RUN apt-get install -qqy libffi-dev libkrb5-dev libev-dev libvirt-dev pkg-config
+RUN apt-get install -qqy libffi-dev libkrb5-dev libev-dev libvirt-dev libsqlite3-dev libxml2-dev libxslt-dev \ 
+    libpq-dev libssl-dev libyaml-dev
+
 
 # Configure and install MySQL
 RUN echo 'mysql-server mysql-server/root_password password devstack' | debconf-set-selections; \

--- a/dockenstack/Dockerfile
+++ b/dockenstack/Dockerfile
@@ -5,13 +5,10 @@ FROM ubuntu:trusty
 MAINTAINER Eric Windisch "ewindisch@docker.com"
 
 EXPOSE 80 5000 8773 8774 8776 9292
-# Set TERM env variable to avoid warning like "debconf: (TERM is not set, so the dialog frontend is not usable.)"
-ENV TERM=xterm
-# Install https methods of apt ; needed to install lxc-docker package
-# Without this, it gives error 'The method driver /usr/lib/apt/methods/https could not be found.'
-RUN apt-get install -qqy apt-transport-https
+# Set DEBIAN_FRONTEND to avoid warning like "debconf: (TERM is not set, so the dialog frontend is not usable.)"
+ENV DEBIAN_FRONTEND="noninteractive"
 # Install Docker
-RUN apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9; \
+RUN apt-get install -qqy apt-transport-https; apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9; \
     echo 'deb http://get.docker.io/ubuntu docker main' > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -qqy lxc-docker


### PR DESCRIPTION
- Installing https method is required before installing lxc-docker otherwise this gives error "The method driver /usr/lib/apt/methods/https could not be found." . 
- During apt package installations , it usually throws warning about setting TERM env variable which can be done at start of dockerfile.
