### PR TITLE
Hint to DockStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Notice
+
+This project is quite dated and might not work as expected. 
+
+For a recent version please also have a look at [janmattfeld/DockStack](https://github.com/janmattfeld/DockStack)
+
 # Openstack on Docker
 
 Dockenstack builds an image for running OpenStack's devstack development and testing environment inside of a Docker container. This image currently supports running the docker and libvirt-lxc virtualization drivers for Nova. KVM/Qemu support is being tested.


### PR DESCRIPTION
As discussed in #29, the README now includes a hint to janmattfeld/DockStack, which addresses all issues and adds the following:

1. Ubuntu 16.04 LTS base image
2. systemd
3. OpenStack Ocata and Pike
4. libvirt/QEMU instance support
5. Zun instead of the deprecated Nova Docker
6. Network configuration